### PR TITLE
Feature: Bring over Windows IME Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 # esy-sdl2
 Esy-enabled build for [SDL2](https://www.libsdl.org/)
 
+# Modifications
+
+A patch by xenotron007 was applied to enable Windows IME candidate list to be shown:
+https://bugzilla.libsdl.org/attachment.cgi?id=3604&action=diff
+
 # License
 
 [SDL License](./LICENSE)

--- a/Windows_IME_Patch.patch
+++ b/Windows_IME_Patch.patch
@@ -1,0 +1,72 @@
+--- a/src/video/windows/SDL_windowskeyboard.c	
++++ a/src/video/windows/SDL_windowskeyboard.c	
+@@ -229,28 +229,37 @@ 
+ }
+ 
+ void
++WIN_UpdateTextInputRect(SDL_VideoData *videodata)
++{
++    HIMC himc = ImmGetContext(videodata->ime_hwnd_current);
++    if (!himc)
++        return;
++
++    CANDIDATEFORM cf;
++    cf.dwIndex = 0;
++    cf.dwStyle = CFS_EXCLUDE;
++    cf.ptCurrentPos.x = videodata->ime_rect.x;
++    cf.ptCurrentPos.y = videodata->ime_rect.y;
++    cf.rcArea.left = videodata->ime_rect.x;
++    cf.rcArea.top = videodata->ime_rect.y;
++    cf.rcArea.right = videodata->ime_rect.x + videodata->ime_rect.w;
++    cf.rcArea.bottom = videodata->ime_rect.y + videodata->ime_rect.h;
++    ImmSetCandidateWindow(himc, &cf);
++
++    ImmReleaseContext(videodata->ime_hwnd_current, himc);
++}
++
++void
+ WIN_SetTextInputRect(_THIS, SDL_Rect *rect)
+ {
+-    SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
+-    HIMC himc = 0;
+-
+     if (!rect) {
+         SDL_InvalidParamError("rect");
+         return;
+     }
+ 
++    SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
+     videodata->ime_rect = *rect;
+-
+-    himc = ImmGetContext(videodata->ime_hwnd_current);
+-    if (himc)
+-    {
+-        COMPOSITIONFORM cf;
+-        cf.ptCurrentPos.x = videodata->ime_rect.x;
+-        cf.ptCurrentPos.y = videodata->ime_rect.y;
+-        cf.dwStyle = CFS_FORCE_POSITION;
+-        ImmSetCompositionWindow(himc, &cf);
+-        ImmReleaseContext(videodata->ime_hwnd_current, himc);
+-    }
++    WIN_UpdateTextInputRect(videodata);
+ }
+ 
+ #ifdef SDL_DISABLE_WINDOWS_IME
+@@ -370,7 +379,8 @@ 
+     videodata->ime_available = SDL_TRUE;
+     IME_UpdateInputLocale(videodata);
+     IME_SetupAPI(videodata);
+-    videodata->ime_uiless = UILess_SetupSinks(videodata);
++    // FIXME: the implementation of UILess IME is incomplete so we disable it by commenting this out:
++    //videodata->ime_uiless = UILess_SetupSinks(videodata);
+     IME_UpdateInputLocale(videodata);
+     IME_Disable(videodata, hwnd);
+ }
+@@ -882,6 +892,7 @@ 
+         *lParam = 0;
+         break;
+     case WM_IME_STARTCOMPOSITION:
++        WIN_UpdateTextInputRect(videodata);
+         trap = SDL_TRUE;
+         break;
+     case WM_IME_COMPOSITION:

--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -232,10 +232,11 @@ void
 WIN_UpdateTextInputRect(SDL_VideoData *videodata)
 {
     HIMC himc = ImmGetContext(videodata->ime_hwnd_current);
+    CANDIDATEFORM cf;
+
     if (!himc)
         return;
 
-    CANDIDATEFORM cf;
     cf.dwIndex = 0;
     cf.dwStyle = CFS_EXCLUDE;
     cf.ptCurrentPos.x = videodata->ime_rect.x;
@@ -252,12 +253,14 @@ WIN_UpdateTextInputRect(SDL_VideoData *videodata)
 void
 WIN_SetTextInputRect(_THIS, SDL_Rect *rect)
 {
+    SDL_VideoData *videodata;
+    
     if (!rect) {
         SDL_InvalidParamError("rect");
         return;
     }
 
-    SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
+    videodata = (SDL_VideoData *)_this->driverdata;
     videodata->ime_rect = *rect;
     WIN_UpdateTextInputRect(videodata);
 }
@@ -340,7 +343,7 @@ static DWORD IME_GetId(SDL_VideoData *videodata, UINT uIndex);
 static void IME_SendEditingEvent(SDL_VideoData *videodata);
 static void IME_DestroyTextures(SDL_VideoData *videodata);
 
-static SDL_bool UILess_SetupSinks(SDL_VideoData *videodata);
+//static SDL_bool UILess_SetupSinks(SDL_VideoData *videodata);
 static void UILess_ReleaseSinks(SDL_VideoData *videodata);
 static void UILess_EnableUIUpdates(SDL_VideoData *videodata);
 static void UILess_DisableUIUpdates(SDL_VideoData *videodata);
@@ -1231,7 +1234,7 @@ UILess_DisableUIUpdates(SDL_VideoData *videodata)
     }
 }
 
-static SDL_bool
+/*static SDL_bool
 UILess_SetupSinks(SDL_VideoData *videodata)
 {
     TfClientId clientid = 0;
@@ -1263,7 +1266,7 @@ UILess_SetupSinks(SDL_VideoData *videodata)
         source->lpVtbl->Release(source);
     }
     return result;
-}
+}*/
 
 #define SAFE_RELEASE(p)                             \
 {                                                   \

--- a/src/video/windows/SDL_windowskeyboard.c
+++ b/src/video/windows/SDL_windowskeyboard.c
@@ -229,28 +229,37 @@ WIN_StopTextInput(_THIS)
 }
 
 void
+WIN_UpdateTextInputRect(SDL_VideoData *videodata)
+{
+    HIMC himc = ImmGetContext(videodata->ime_hwnd_current);
+    if (!himc)
+        return;
+
+    CANDIDATEFORM cf;
+    cf.dwIndex = 0;
+    cf.dwStyle = CFS_EXCLUDE;
+    cf.ptCurrentPos.x = videodata->ime_rect.x;
+    cf.ptCurrentPos.y = videodata->ime_rect.y;
+    cf.rcArea.left = videodata->ime_rect.x;
+    cf.rcArea.top = videodata->ime_rect.y;
+    cf.rcArea.right = videodata->ime_rect.x + videodata->ime_rect.w;
+    cf.rcArea.bottom = videodata->ime_rect.y + videodata->ime_rect.h;
+    ImmSetCandidateWindow(himc, &cf);
+
+    ImmReleaseContext(videodata->ime_hwnd_current, himc);
+}
+
+void
 WIN_SetTextInputRect(_THIS, SDL_Rect *rect)
 {
-    SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
-    HIMC himc = 0;
-
     if (!rect) {
         SDL_InvalidParamError("rect");
         return;
     }
 
+    SDL_VideoData *videodata = (SDL_VideoData *)_this->driverdata;
     videodata->ime_rect = *rect;
-
-    himc = ImmGetContext(videodata->ime_hwnd_current);
-    if (himc)
-    {
-        COMPOSITIONFORM cf;
-        cf.ptCurrentPos.x = videodata->ime_rect.x;
-        cf.ptCurrentPos.y = videodata->ime_rect.y;
-        cf.dwStyle = CFS_FORCE_POSITION;
-        ImmSetCompositionWindow(himc, &cf);
-        ImmReleaseContext(videodata->ime_hwnd_current, himc);
-    }
+    WIN_UpdateTextInputRect(videodata);
 }
 
 #ifdef SDL_DISABLE_WINDOWS_IME
@@ -370,7 +379,8 @@ IME_Init(SDL_VideoData *videodata, HWND hwnd)
     videodata->ime_available = SDL_TRUE;
     IME_UpdateInputLocale(videodata);
     IME_SetupAPI(videodata);
-    videodata->ime_uiless = UILess_SetupSinks(videodata);
+    // FIXME: the implementation of UILess IME is incomplete so we disable it by commenting this out:
+    //videodata->ime_uiless = UILess_SetupSinks(videodata);
     IME_UpdateInputLocale(videodata);
     IME_Disable(videodata, hwnd);
 }
@@ -882,6 +892,7 @@ IME_HandleMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM *lParam, SDL_VideoD
         *lParam = 0;
         break;
     case WM_IME_STARTCOMPOSITION:
+        WIN_UpdateTextInputRect(videodata);
         trap = SDL_TRUE;
         break;
     case WM_IME_COMPOSITION:


### PR DESCRIPTION
This brings over a Windows IME Patch:
https://bugzilla.libsdl.org/attachment.cgi?id=3604&action=diff

Discussed in this thread: https://bugzilla.libsdl.org/show_bug.cgi?id=3421

One notable omission in the current patch is that it doesn't handle IME in the "true fullscreen" case - but that case is geared more for games and is not currently used by Onivim 2 / Revery.