### PR TITLE
Split up build to run without X11 on mac.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "license": "MIT",
   "esy": {
     "build": [
-        ["bash", "-c", "#{os == 'windows' ? 'SHELL=bash CC=x86_64-w64-mingw32-gcc WINDRES=x86_64-w64-mingw32-windres SDL_THREAD_PTHREAD=1 ./configure --prefix=$cur__install --enable-pthreads' : './configure --prefix=$cur__install'}"],
+        ["bash", "-c", "#{os == 'windows' ? 'SHELL=bash CC=x86_64-w64-mingw32-gcc WINDRES=x86_64-w64-mingw32-windres SDL_THREAD_PTHREAD=1 ./configure --prefix=$cur__install --enable-pthreads' : 'echo'}"],
+        ["bash", "-c", "#{os == 'darwin' ? './configure --disable-video-x11 --prefix=$cur__install' : 'echo'}"],
+        ["bash", "-c", "#{os == 'macOS' ? './configure --disable-video-x11 --prefix=$cur__install' : 'echo'}"],
+        ["bash", "-c", "#{os == 'linux' ? './configure --prefix=$cur__install' : 'echo'}"],
         ["make"],
         ["make", "install"]
     ],


### PR DESCRIPTION
This got it building on my Mac that was having issues with `<X11/Xlib.h>`: https://gist.github.com/CrossR/a295dd4fa6031a20f6fa70f3f61f2ec3.