### PR TITLE
Struct polymorphism: fix member ordering

### DIFF
--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -18,6 +18,6 @@ steps:
     displayName: Publish log
     condition: always()
     inputs:
-      pathToPublish: "C:\\npm\cache\\_logs"
+      pathToPublish: "C:\\npm\\cache\\_logs"
       artifactName: log
       artifactType: container

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -18,6 +18,6 @@ steps:
     displayName: Publish log
     condition: always()
     inputs:
-      pathToPublish: "C:\npm\cache\_logs"
+      pathToPublish: "C:\\npm\cache\\_logs"
       artifactName: log
       artifactType: container

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -16,7 +16,7 @@ steps:
       ESY__LOG: 'debug'
   - task: PublishBuildArtifacts@1
     displayName: Publish log
-    condition: always()
+    condition: and(failed(), eq(variables['Agent.OS'], 'Windows_NT'))
     inputs:
       pathToPublish: "C:\\npm\\cache\\_logs"
       artifactName: log

--- a/.ci/esy-build-steps.yml
+++ b/.ci/esy-build-steps.yml
@@ -14,3 +14,10 @@ steps:
     displayName: 'esy build --verbosity=debug'
     env:
       ESY__LOG: 'debug'
+  - task: PublishBuildArtifacts@1
+    displayName: Publish log
+    condition: always()
+    inputs:
+      pathToPublish: "C:\npm\cache\_logs"
+      artifactName: log
+      artifactType: container

--- a/include/SDL_events.h
+++ b/include/SDL_events.h
@@ -322,11 +322,11 @@ typedef struct SDL_MouseWheelEvent
 
 typedef struct SDL_PanEvent
 {
-    Uint64 x;      /**< Precise scrolling amount on x axis. */
-    Uint64 y;      /**< Precise scrolling amount on y axis. */
     Uint32 type;          /**< ::SDL_PANEVENT */
     Uint32 timestamp;   /**< In milliseconds, populated using SDL_GetTicks() */
     Uint32 windowID;    /**< The window with mouse focus, if any */
+    Uint64 x;      /**< Precise scrolling amount on x axis. */
+    Uint64 y;      /**< Precise scrolling amount on y axis. */
     Uint32 which;       /**< The mouse instance id, or SDL_TOUCH_MOUSEID */
     Uint32 source_type; /**< One of SDL_MOUSEWHEEL_SOURCE_[...] */
     Uint8  contains_x; /**< Indicates event contains a useful value in scalar_x and a pan should be calculated */


### PR DESCRIPTION
Fixes an incorrect struct packing optimization that was causing event type to be misread