### PR TITLE
Remove default close action

### DIFF
--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -341,7 +341,7 @@ CreateApplicationMenus(void)
     windowMenu = [[NSMenu alloc] initWithTitle:@"Window"];
 
     /* Add menu items */
-    // ONIVIM: Disable this default action
+    // ONIVIM #1169 / #992: Disable this default action
     // [windowMenu addItemWithTitle:@"Close" action:@selector(performClose:) keyEquivalent:@"w"];
 
     [windowMenu addItemWithTitle:@"Minimize" action:@selector(performMiniaturize:) keyEquivalent:@"m"];

--- a/src/video/cocoa/SDL_cocoaevents.m
+++ b/src/video/cocoa/SDL_cocoaevents.m
@@ -341,7 +341,8 @@ CreateApplicationMenus(void)
     windowMenu = [[NSMenu alloc] initWithTitle:@"Window"];
 
     /* Add menu items */
-    [windowMenu addItemWithTitle:@"Close" action:@selector(performClose:) keyEquivalent:@"w"];
+    // ONIVIM: Disable this default action
+    // [windowMenu addItemWithTitle:@"Close" action:@selector(performClose:) keyEquivalent:@"w"];
 
     [windowMenu addItemWithTitle:@"Minimize" action:@selector(performMiniaturize:) keyEquivalent:@"m"];
 


### PR DESCRIPTION
This removes the default menu item to close a window, with the shortcut `Cmd+W`. This gives us the opportunity to handle the event in userspace.

Hopefully, once we have tighter menu integration in Revery - we can just build a custom menu there w/o needing to modify SDL2.

__Related:__
onivim/oni2#1169
onivim/oni2#992