### PR TITLE
SDL_DragEvent: Add SDL_DragEvents

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 # esy-sdl2
 Esy-enabled build for [SDL2](https://www.libsdl.org/)
 
-# Modifications
+## Modifications
 
-A patch by xenotron007 was applied to enable Windows IME candidate list to be shown:
-https://bugzilla.libsdl.org/attachment.cgi?id=3604&action=diff
+- A patch by xenotron007 was applied to enable Windows IME candidate list to be shown: https://bugzilla.libsdl.org/attachment.cgi?id=3604&action=diff
+- A patch by [@zbaylin](https://github.com/zbaylin) was made to add drag events that closely mirror the built-in drop events
 
-# License
+
+## License
 
 [SDL License](./LICENSE)

--- a/include/SDL_events.h
+++ b/include/SDL_events.h
@@ -157,6 +157,12 @@ typedef enum
     /* Pan events */
     SDL_PANEVENT = 0x2100,
 
+    /* Drag events */
+    SDL_DRAGFILE = 0x2200,
+    SDL_DRAGTEXT,
+    SDL_DRAGBEGIN,
+    SDL_DRAGCOMPLETE,
+
     /** Events ::SDL_USEREVENT through ::SDL_LASTEVENT are for your use,
      *  and should be allocated with SDL_RegisterEvents()
      */
@@ -533,6 +539,16 @@ typedef struct SDL_DropEvent
 } SDL_DropEvent;
 
 
+typedef struct SDL_DragEvent
+{
+    Uint32 type;
+    Uint32 timestamp;
+    char *file;
+    Uint32 windowID;
+    Sint32 x;
+    Sint32 y;
+} SDL_DragEvent;
+
 /**
  *  \brief Sensor event structure (event.sensor.*)
  */
@@ -624,7 +640,7 @@ typedef union SDL_Event
     SDL_MultiGestureEvent mgesture; /**< Gesture event data */
     SDL_DollarGestureEvent dgesture; /**< Gesture event data */
     SDL_DropEvent drop;             /**< Drag and drop event data */
-    
+    SDL_DragEvent drag;
     SDL_PanEvent pan; /**< Obsolesces mouse wheel events */
 
     /* This is necessary for ABI compatibility between Visual C++ and GCC

--- a/src/events/SDL_dragevents.c
+++ b/src/events/SDL_dragevents.c
@@ -1,0 +1,64 @@
+#include "../SDL_internal.h"
+
+#include "SDL_events.h"
+#include "SDL_events_c.h"
+#include "SDL_dragevents_c.h"
+
+#include "../video/SDL_sysvideo.h"  /* for SDL_Window internals. */
+
+const int
+SDL_SendDrag(SDL_Window *window, const SDL_EventType evtype, const char *data, int x, int y)
+{
+    static SDL_bool app_is_dragging = SDL_FALSE;
+    int posted = 0;
+
+    const SDL_bool need_begin = window ? !window->is_dragging : !app_is_dragging;
+    SDL_Event event;
+
+    if (need_begin) {
+        SDL_zero(event);
+        event.type = SDL_DRAGBEGIN;
+        event.drag.x = x;
+        event.drag.y = y;
+
+        if (window) {
+            event.drag.windowID = window->id;
+        }
+
+        posted = (SDL_PushEvent(&event) > 0);
+        if (!posted) {
+            return 0;
+        }
+        if (window) {
+            window->is_dragging = SDL_TRUE;
+        } else {
+            app_is_dragging = SDL_TRUE;
+        }
+    }
+
+    SDL_zero(event);
+    event.type = evtype;
+    event.drag.file = data ? SDL_strdup(data) : NULL;
+    event.drag.windowID = window ? window->id : 0;
+    event.drag.x = x;
+    event.drag.y = y;
+    posted = (SDL_PushEvent(&event) > 0);
+
+    if (posted && (evtype == SDL_DRAGCOMPLETE)) {
+        if (window) {
+            window->is_dragging = SDL_FALSE;
+        } else {
+            app_is_dragging = SDL_FALSE;
+        }
+    }
+    return posted;
+}
+
+int SDL_SendDragFile(SDL_Window *window, const char *file, int x, int y)
+{
+    return SDL_SendDrag(window, SDL_DRAGFILE, file, x, y);
+}
+
+int SDL_SendDragComplete(SDL_Window *window, int x, int y) {
+    return SDL_SendDrag(window, SDL_DRAGCOMPLETE, NULL, x, y);
+}

--- a/src/events/SDL_dragevents_c.h
+++ b/src/events/SDL_dragevents_c.h
@@ -1,0 +1,8 @@
+#include "../SDL_internal.h"
+
+#ifndef SDL_dragevents_c_h_
+#define SDL_dragevents_c_h_
+
+extern int SDL_SendDragFile(SDL_Window *window, const char *file, int x, int y);
+extern int SDL_SendDragComplete(SDL_Window *window, int x, int y);
+#endif

--- a/src/events/SDL_events_c.h
+++ b/src/events/SDL_events_c.h
@@ -31,6 +31,7 @@
 
 #include "SDL_clipboardevents_c.h"
 #include "SDL_displayevents_c.h"
+#include "SDL_dragevents_c.h"
 #include "SDL_dropevents_c.h"
 #include "SDL_gesture_c.h"
 #include "SDL_keyboard_c.h"

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -100,6 +100,7 @@ struct SDL_Window
     SDL_bool is_hiding;
     SDL_bool is_destroying;
     SDL_bool is_dropping;       /* drag/drop in progress, expecting SDL_SendDropComplete(). */
+    SDL_bool is_dragging;
 
     SDL_WindowShaper *shaper;
 
@@ -380,11 +381,11 @@ struct SDL_VideoDevice
     /* Data private to this driver */
     void *driverdata;
     struct SDL_GLDriverData *gl_data;
-    
+
 #if SDL_VIDEO_OPENGL_EGL
     struct SDL_EGL_VideoData *egl_data;
 #endif
-    
+
 #if SDL_VIDEO_OPENGL_ES || SDL_VIDEO_OPENGL_ES2
     struct SDL_PrivateGLESData *gles_data;
 #endif

--- a/src/video/SDL_sysvideo.h
+++ b/src/video/SDL_sysvideo.h
@@ -381,11 +381,11 @@ struct SDL_VideoDevice
     /* Data private to this driver */
     void *driverdata;
     struct SDL_GLDriverData *gl_data;
-
+    
 #if SDL_VIDEO_OPENGL_EGL
     struct SDL_EGL_VideoData *egl_data;
 #endif
-
+    
 #if SDL_VIDEO_OPENGL_ES || SDL_VIDEO_OPENGL_ES2
     struct SDL_PrivateGLESData *gles_data;
 #endif

--- a/src/video/cocoa/SDL_cocoawindow.m
+++ b/src/video/cocoa/SDL_cocoawindow.m
@@ -763,7 +763,7 @@ SetWindowStyle(SDL_Window * window, NSUInteger style)
 
     isFullscreenSpace = NO;
     inFullscreenTransition = NO;
-
+    
     [self windowDidExitFullScreen:nil];
 }
 
@@ -779,7 +779,7 @@ SetWindowStyle(SDL_Window * window, NSUInteger style)
         pendingWindowOperation = PENDING_OPERATION_NONE;
         [self setFullscreenSpace:NO];
     } else {
-        /* Unset the resizable flag.
+        /* Unset the resizable flag. 
            This is a workaround for https://bugzilla.libsdl.org/show_bug.cgi?id=3697
          */
         SetWindowStyle(window, [nswindow styleMask] & (~NSWindowStyleMaskResizable));
@@ -815,16 +815,16 @@ SetWindowStyle(SDL_Window * window, NSUInteger style)
 - (void)windowDidFailToExitFullScreen:(NSNotification *)aNotification
 {
     SDL_Window *window = _data->window;
-
+    
     if (window->is_destroying) {
         return;
     }
 
     SetWindowStyle(window, (NSWindowStyleMaskTitled|NSWindowStyleMaskClosable|NSWindowStyleMaskMiniaturizable|NSWindowStyleMaskResizable));
-
+    
     isFullscreenSpace = YES;
     inFullscreenTransition = NO;
-
+    
     [self windowDidEnterFullScreen:nil];
 }
 
@@ -1526,7 +1526,7 @@ Cocoa_CreateWindow(_THIS, SDL_Window * window)
     if (!(window->flags & SDL_WINDOW_OPENGL)) {
         return 0;
     }
-
+    
     /* The rest of this macro mess is for OpenGL or OpenGL ES windows */
 #if SDL_VIDEO_OPENGL_ES2
     if (_this->gl_config.profile_mask == SDL_GL_CONTEXT_PROFILE_ES) {
@@ -1946,7 +1946,7 @@ Cocoa_DestroyWindow(_THIS, SDL_Window * window)
 
         NSArray *contexts = [[data->nscontexts copy] autorelease];
         for (SDLOpenGLContext *context in contexts) {
-            /* Calling setWindow:NULL causes the context to remove itself from the context list. */
+            /* Calling setWindow:NULL causes the context to remove itself from the context list. */            
             [context setWindow:NULL];
         }
         [data->nscontexts release];

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -1364,9 +1364,7 @@ X11_DispatchEvent(_THIS)
             if (target == data->xdnd_req) {
                 /* read data */
                 SDL_x11Prop p;
-                int mouseX = xevent.xmotion.x;
-                int mouseY = xevent.xmotion.y;
-
+                SDL_Mouse *mouse = SDL_GetMouse();
 
                 X11_ReadProperty(&p, display, data->xwindow, videodata->PRIMARY);
 
@@ -1383,7 +1381,7 @@ X11_DispatchEvent(_THIS)
                                 if (data->dropping) {
                                     SDL_SendDropFile(data->window, fn);
                                 } else if (data->dragging) {
-                                    SDL_SendDragFile(data->window, fn, mouseX, mouseY);
+                                    SDL_SendDragFile(data->window, fn, mouse->x, mouse->y);
                                 }
                             }
                         }
@@ -1392,7 +1390,7 @@ X11_DispatchEvent(_THIS)
                     if (data->dropping) {
                         SDL_SendDropComplete(data->window);
                     } else if (data->dragging) {
-                        SDL_SendDragComplete(data->window, mouseX, mouseY);
+                        SDL_SendDragComplete(data->window, mouse->x, mouse->y);
                     }
                 }
                 X11_XFree(p.data);

--- a/src/video/x11/SDL_x11events.c
+++ b/src/video/x11/SDL_x11events.c
@@ -43,7 +43,7 @@
 
 #include <stdio.h>
 
-/*#define DEBUG_XEVENTS*/
+#define DEBUG_XEVENTS
 
 #ifndef _NET_WM_MOVERESIZE_SIZE_TOPLEFT
 #define _NET_WM_MOVERESIZE_SIZE_TOPLEFT      0
@@ -982,7 +982,7 @@ X11_DispatchEvent(_THIS)
                                         &xevent.xconfigure.x, &xevent.xconfigure.y,
                                         &ChildReturn);
             }
-                
+
             if (xevent.xconfigure.x != data->last_xconfigure.x ||
                 xevent.xconfigure.y != data->last_xconfigure.y) {
                 SDL_SendWindowEvent(data->window, SDL_WINDOWEVENT_MOVED,
@@ -1057,6 +1057,26 @@ X11_DispatchEvent(_THIS)
                 m.data.l[4] = videodata->XdndActionCopy; /* we only accept copying anyway */
 
                 X11_XSendEvent(display, xevent.xclient.data.l[0], False, NoEventMask, (XEvent*)&m);
+
+                if (data->xdnd_req == None) {
+                    memset(&m, 0, sizeof(XClientMessageEvent));
+                    m.type = ClientMessage;
+                    m.display = xevent.xclient.display;
+                    m.window = xevent.xclient.data.l[0];
+                    m.message_type = videodata->XdndFinished;
+                    m.format=32;
+                    m.data.l[0] = data->xwindow;
+                    m.data.l[1] = 0;
+                    m.data.l[2] = None; /* fail! */
+                    X11_XSendEvent(display, xevent.xclient.data.l[0], False, NoEventMask, (XEvent*)&m);
+                } else {
+                    data->dragging = SDL_TRUE;
+                    if(xdnd_version >= 1) {
+                        X11_XConvertSelection(display, videodata->XdndSelection, data->xdnd_req, videodata->PRIMARY, data->xwindow, xevent.xclient.data.l[2]);
+                    } else {
+                        X11_XConvertSelection(display, videodata->XdndSelection, data->xdnd_req, videodata->PRIMARY, data->xwindow, CurrentTime);
+                    }
+                }
                 X11_XFlush(display);
             }
             else if(xevent.xclient.message_type == videodata->XdndDrop) {
@@ -1074,6 +1094,7 @@ X11_DispatchEvent(_THIS)
                     X11_XSendEvent(display, xevent.xclient.data.l[0], False, NoEventMask, (XEvent*)&m);
                 } else {
                     /* convert */
+                    data->dropping = SDL_TRUE;
                     if(xdnd_version >= 1) {
                         X11_XConvertSelection(display, videodata->XdndSelection, data->xdnd_req, videodata->PRIMARY, data->xwindow, xevent.xclient.data.l[2]);
                     } else {
@@ -1343,6 +1364,10 @@ X11_DispatchEvent(_THIS)
             if (target == data->xdnd_req) {
                 /* read data */
                 SDL_x11Prop p;
+                int mouseX = xevent.xmotion.x;
+                int mouseY = xevent.xmotion.y;
+
+
                 X11_ReadProperty(&p, display, data->xwindow, videodata->PRIMARY);
 
                 if (p.format == 8) {
@@ -1355,26 +1380,39 @@ X11_DispatchEvent(_THIS)
                         } else if (SDL_strcmp("text/uri-list", name)==0) {
                             char *fn = X11_URIToLocal(token);
                             if (fn) {
-                                SDL_SendDropFile(data->window, fn);
+                                if (data->dropping) {
+                                    SDL_SendDropFile(data->window, fn);
+                                } else if (data->dragging) {
+                                    SDL_SendDragFile(data->window, fn, mouseX, mouseY);
+                                }
                             }
                         }
                         token = strtok(NULL, "\r\n");
                     }
-                    SDL_SendDropComplete(data->window);
+                    if (data->dropping) {
+                        SDL_SendDropComplete(data->window);
+                    } else if (data->dragging) {
+                        SDL_SendDragComplete(data->window, mouseX, mouseY);
+                    }
                 }
                 X11_XFree(p.data);
 
-                /* send reply */
-                SDL_memset(&m, 0, sizeof(XClientMessageEvent));
-                m.type = ClientMessage;
-                m.display = display;
-                m.window = data->xdnd_source;
-                m.message_type = videodata->XdndFinished;
-                m.format = 32;
-                m.data.l[0] = data->xwindow;
-                m.data.l[1] = 1;
-                m.data.l[2] = videodata->XdndActionCopy;
-                X11_XSendEvent(display, data->xdnd_source, False, NoEventMask, (XEvent*)&m);
+                if (data->dropping) {
+                    /* send reply */
+                    SDL_memset(&m, 0, sizeof(XClientMessageEvent));
+                    m.type = ClientMessage;
+                    m.display = display;
+                    m.window = data->xdnd_source;
+                    m.message_type = videodata->XdndFinished;
+                    m.format = 32;
+                    m.data.l[0] = data->xwindow;
+                    m.data.l[1] = 1;
+                    m.data.l[2] = videodata->XdndActionCopy;
+                    X11_XSendEvent(display, data->xdnd_source, False, NoEventMask, (XEvent*)&m);
+                }
+
+                data->dragging = SDL_FALSE;
+                data->dropping = SDL_FALSE;
 
                 X11_XSync(display, False);
             }

--- a/src/video/x11/SDL_x11window.h
+++ b/src/video/x11/SDL_x11window.h
@@ -29,7 +29,7 @@
 */
 #define PENDING_FOCUS_TIME   200
 
-#if SDL_VIDEO_OPENGL_EGL   
+#if SDL_VIDEO_OPENGL_EGL
 #include <EGL/egl.h>
 #endif
 
@@ -67,8 +67,10 @@ typedef struct
     struct SDL_VideoData *videodata;
     unsigned long user_time;
     Atom xdnd_req;
+    SDL_bool dragging;
+    SDL_bool dropping;
     Window xdnd_source;
-#if SDL_VIDEO_OPENGL_EGL  
+#if SDL_VIDEO_OPENGL_EGL
     EGLSurface egl_surface;
 #endif
 } SDL_WindowData;


### PR DESCRIPTION
These closely mirror the Drop events, specifically with BEGIN and COMPLETE. When dragging n files, 1 BEGIN, n FILE and 1 COMPLETE events are sent per mouse movement.


Note that currently only the macOS implementation works, but the scaffolding is there for easy Windows/Linux additions!